### PR TITLE
Reduce ReactNativeWindow Warnings

### DIFF
--- a/ReactWindows/ChakraBridge/NativeJavaScriptExecutor.cpp
+++ b/ReactWindows/ChakraBridge/NativeJavaScriptExecutor.cpp
@@ -39,7 +39,7 @@ ChakraStringResult NativeJavaScriptExecutor::GetGlobalVariable(String^ variableN
     size_t bufLen;
     IfFailRetNullPtr(JsStringToPointer(globalVariableJson, &szBuf, &bufLen));
 
-    ChakraStringResult finalResult = { JsNoError, ref new String(szBuf, bufLen) };
+    ChakraStringResult finalResult = { JsNoError, ref new String(szBuf, (unsigned int)bufLen) };
     return finalResult;
 }
 
@@ -92,7 +92,7 @@ ChakraStringResult NativeJavaScriptExecutor::CallFunctionAndReturnFlushedQueue(S
     size_t bufLen;
     IfFailRetNullPtr(JsStringToPointer(stringifiedResult, &szBuf, &bufLen));
 
-    ChakraStringResult finalResult = { JsNoError, ref new String(szBuf, bufLen) };
+    ChakraStringResult finalResult = { JsNoError, ref new String(szBuf, (unsigned int)bufLen) };
     return finalResult;
 }
 
@@ -130,7 +130,7 @@ ChakraStringResult NativeJavaScriptExecutor::InvokeCallbackAndReturnFlushedQueue
     size_t bufLen;
     IfFailRetNullPtr(JsStringToPointer(stringifiedResult, &szBuf, &bufLen));
 
-    ChakraStringResult finalResult = { JsNoError, ref new String(szBuf, bufLen) };
+    ChakraStringResult finalResult = { JsNoError, ref new String(szBuf, (unsigned int)bufLen) };
     return finalResult;
 }
 
@@ -159,6 +159,6 @@ ChakraStringResult NativeJavaScriptExecutor::FlushedQueue()
     size_t bufLen;
     IfFailRetNullPtr(JsStringToPointer(stringifiedResult, &szBuf, &bufLen));
 
-    ChakraStringResult finalResult = { JsNoError, ref new String(szBuf, bufLen) };
+    ChakraStringResult finalResult = { JsNoError, ref new String(szBuf, (unsigned int)bufLen) };
     return finalResult;
 }

--- a/ReactWindows/ReactNative.Net46/Modules/Launcher/LauncherModule.cs
+++ b/ReactWindows/ReactNative.Net46/Modules/Launcher/LauncherModule.cs
@@ -46,7 +46,7 @@ namespace ReactNative.Modules.Launch
         /// The promise that should be resolved after the URL is opened.
         /// </param>
         [ReactMethod]
-        public async void openURL(string url, IPromise promise)
+        public void openURL(string url, IPromise promise)
         {
             if (url == null)
             {
@@ -80,7 +80,7 @@ namespace ReactNative.Modules.Launch
         /// The promise used to return the result of the check.
         /// </param>
         [ReactMethod]
-        public async void canOpenURL(string url, IPromise promise)
+        public void canOpenURL(string url, IPromise promise)
         {
             if (url == null)
             {
@@ -97,9 +97,6 @@ namespace ReactNative.Modules.Launch
 
             try
             {
-                // TODO: Figure out the WPF way to launch from a URL. See also: https://msdn.microsoft.com/en-us/library/aa767914(v=vs.85).aspx
-                //var support = await Launcher.QueryUriSupportAsync(uri, LaunchQuerySupportType.Uri).AsTask().ConfigureAwait(false);
-                //promise.Resolve(support == LaunchQuerySupportStatus.Available);
                 promise.Resolve(true);
             }
             catch (Exception ex)

--- a/ReactWindows/ReactNative.Net46/Modules/NetInfo/INetworkInformation.cs
+++ b/ReactWindows/ReactNative.Net46/Modules/NetInfo/INetworkInformation.cs
@@ -32,9 +32,19 @@ namespace ReactNative.Modules.NetInfo
         void Stop();
     }
 
+    /// <summary>
+    /// Describes a network connectivity change event
+    /// </summary>
     public class NetworkConnectivityChangedEventArgs : EventArgs
     {
+        /// <summary>
+        /// Gets or sets a value indicating whether the network is available
+        /// </summary>
         public bool IsAvailable { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying additional network connectivity status
+        /// </summary>
         public string ConnectionStatus { get; set; }
     }
 }

--- a/ReactWindows/ReactNative.Net46/Views/Scroll/ReactScrollViewManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Scroll/ReactScrollViewManager.cs
@@ -127,11 +127,11 @@ namespace ReactNative.Views.Scroll
         public void SetHorizontal(ScrollViewer view, bool horizontal)
         {
             throw new NotImplementedException();
-            var horizontalScrollMode = horizontal
-                ? ScrollBarVisibility.Auto
-                : ScrollBarVisibility.Disabled;
+            // var horizontalScrollMode = horizontal
+            //    ? ScrollBarVisibility.Auto
+            //    : ScrollBarVisibility.Disabled;
 
-            view.HorizontalScrollBarVisibility = _scrollViewerData[view].HorizontalScrollBarVisibility = horizontalScrollMode;
+            // view.HorizontalScrollBarVisibility = _scrollViewerData[view].HorizontalScrollBarVisibility = horizontalScrollMode;
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative.Shared/DevSupport/DisabledDevSupportManager.cs
+++ b/ReactWindows/ReactNative.Shared/DevSupport/DisabledDevSupportManager.cs
@@ -75,6 +75,8 @@ namespace ReactNative.DevSupport
                 ExceptionDispatchInfo.Capture(exception).Throw();
             }).AsTask().ConfigureAwait(false);
 #else
+            await Task.Delay(0);
+
             DispatcherHelpers.RunOnDispatcher(() => ExceptionDispatchInfo.Capture(exception).Throw());
 #endif
         }

--- a/ReactWindows/ReactNative.Shared/Extensions/Array.cs
+++ b/ReactWindows/ReactNative.Shared/Extensions/Array.cs
@@ -1,7 +1,14 @@
 ﻿namespace Extensions
 {
+    /// <summary>
+    /// Generic implementation of an Array
+    /// </summary>
+    /// <typeparam name="T">The type of array</typeparam>
     public static class Array<T>
     {
+        /// <summary>
+        /// Create an empty array of specified type
+        /// </summary>
         public static readonly T[] Empty = new T[0];
     }
 }

--- a/ReactWindows/ReactNative.Shared/Views/TextInput/ReactTextInputBlurEvent.cs
+++ b/ReactWindows/ReactNative.Shared/Views/TextInput/ReactTextInputBlurEvent.cs
@@ -2,10 +2,16 @@
 using ReactNative.UIManager.Events;
 using System;
 
+#if WINDOWS_UWP
+using Windows.UI.Xaml.Controls;
+#else
+using System.Windows.Controls;
+#endif
+
 namespace ReactNative.Views.TextInput
 {
     /// <summary>
-    /// Event emitted by <see cref="Windows.UI.Xaml.Controls.TextBox"/> native 
+    /// Event emitted by <see cref="TextBox"/> native 
     /// view when the control gains focus.
     /// </summary>
     class ReactTextInputBlurEvent : Event

--- a/ReactWindows/ReactNative/Views/Image/ReactImageManager.cs
+++ b/ReactWindows/ReactNative/Views/Image/ReactImageManager.cs
@@ -329,6 +329,8 @@ namespace ReactNative.Views.Image
         /// </summary>
         /// <param name="view">The image view instance.</param>
         /// <param name="source">The source URI.</param>
+        /// <param name="tintColor">The tint color</param>
+        /// <param name="backgroundColor">The background color</param>
         private async void SetUriFromSingleSource(Border view, string source, Color? tintColor, Color? backgroundColor)
         {
             var imageBrush = (ImageBrush)view.Background;


### PR DESCRIPTION
The ReactNative.Net46 creates about 10 warnings that can be easily resolved... These warnings don't "MATTER" to the functionality of the framework, but they do cause warnings in projects the NPM link to the ReactNative framework... If those projects desire to add a "No Warnings" check to their CI process they would have to create special logic to ignore warnings from a specific class... Since the warnings can be easily fixed I don't see any reason to not fix them...

The only warning that persists is in ReactNative UWP in generated code... This is a documentation missing warning that will need to be solved by configuring the code generator tool... The file itself has some documentation on members, but not on the class itself... This PR does not address that warning...