### PR TITLE
DOOF-2221: Add serialization of error object ReactNative.Chakra.JavaS…

### DIFF
--- a/ReactWindows/ReactNative.Net46/Chakra/JavaScriptScriptException.cs
+++ b/ReactWindows/ReactNative.Net46/Chakra/JavaScriptScriptException.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Runtime.Serialization;
+using System.Security.Permissions;
+
+namespace ReactNative.Chakra
+{
+    public sealed partial class JavaScriptScriptException : JavaScriptException
+    {
+        [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+            {
+                throw new ArgumentException(nameof(info));
+            }
+            info.AddValue("Error", Error);
+            base.GetObjectData(info, context);
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Net46/ReactNative.Net46.csproj
+++ b/ReactWindows/ReactNative.Net46/ReactNative.Net46.csproj
@@ -149,6 +149,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Bridge\DispatcherHelpers.cs" />
+    <Compile Include="Chakra\JavaScriptScriptException.cs" />
     <Compile Include="DevSupport\DevOptionDialog.xaml.cs">
       <DependentUpon>DevOptionDialog.xaml</DependentUpon>
     </Compile>

--- a/ReactWindows/ReactNative.Shared/Chakra/JavaScriptCallFunctionException.cs
+++ b/ReactWindows/ReactNative.Shared/Chakra/JavaScriptCallFunctionException.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json.Linq;
+
+namespace ReactNative.Shared.Chakra
+{
+    [Serializable]
+    public class JavaScriptCallFunctionException : Exception
+    {
+        private readonly string moduleName;
+        private readonly string methodName;
+        private readonly JArray arguments;
+
+        public string ModuleName
+        {
+            get { return moduleName; }
+        }
+
+        public string MethodName
+        {
+            get { return methodName; }
+        }
+
+        public JArray Arguments
+        {
+            get { return arguments; }
+        }
+
+        public JavaScriptCallFunctionException(string moduleName, string methodName, JArray arguments, Exception innerException) : base("JavaScript call fuction exception", innerException)
+        {
+            this.moduleName = moduleName;
+            this.methodName = methodName;
+            this.arguments = arguments;
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Shared/Chakra/JavaScriptScriptException.cs
+++ b/ReactWindows/ReactNative.Shared/Chakra/JavaScriptScriptException.cs
@@ -3,7 +3,7 @@ namespace ReactNative.Chakra
     /// <summary>
     ///     A script exception.
     /// </summary>
-    public sealed class JavaScriptScriptException : JavaScriptException
+    public sealed partial class JavaScriptScriptException : JavaScriptException
     {
         /// <summary>
         /// The error.

--- a/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
+++ b/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
@@ -73,6 +73,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Chakra\Executor\LogLevel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Chakra\JavaScriptBackgroundWorkItemCallback.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Chakra\JavaScriptBeforeCollectCallback.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Chakra\JavaScriptCallFunctionException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Chakra\JavaScriptContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Chakra\JavaScriptEngineException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Chakra\JavaScriptErrorCode.cs" />


### PR DESCRIPTION
…criptScriptException

- No changes made to UWP part regarding JavaScriptScriptException as there is no ``GetObjectData`` method. So, it works by default.

- Also these changes not giving better understanding in what point in JS exception really occurred. For example, if I add exception to ``renderCalendarPreferenceContent ()`` method in file ``PreferencesModal.js``, during runtime I will get the following values in exception:
ModuleName: RCTEventEmitter
MethodName: receiveTouches
And touch input parameters in arguments.
No points to ``renderCalendarPreferenceContent ()`` method.
