### PR TITLE
ReactNative Elements visible for automation

### DIFF
--- a/ReactWindows/ReactNative.Net46/Views/Image/ReactImageManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Image/ReactImageManager.cs
@@ -331,21 +331,38 @@ namespace ReactNative.Views.Image
         }
     }
 
+    /// <summary>
+    /// Custom peer class deriving from FrameworkElementAutomationPeer
+    /// </summary>
     public class ModifiedBorderAutomationPeer : FrameworkElementAutomationPeer
     {
+        /// <summary>
+        /// Modified Border with interactive role.
+        /// </summary>
+        /// <param name="owner">The Border instance.</param>
         public ModifiedBorderAutomationPeer(Border owner) : base(owner)
         {
 
         }
 
+        /// <summary>
+        /// Interactive role in the user interface
+        /// </summary>
+        /// <returns> Boolean </returns>
         protected override bool IsControlElementCore()
         {
             return true;
         }
     }
 
+    /// <summary>
+    /// Class providing automation support for the Border element.
+    /// </summary>
     public class UIAutomationBorder : Border
     {
+        /// <summary>
+        /// Class specific AutomationPeer implementation
+        /// </summary>
         protected override AutomationPeer OnCreateAutomationPeer()
         {
             return new ModifiedBorderAutomationPeer(this);

--- a/ReactWindows/ReactNative.Net46/Views/Image/ReactImageManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Image/ReactImageManager.cs
@@ -11,6 +11,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using System.Windows.Automation.Peers;
 
 namespace ReactNative.Views.Image
 {
@@ -224,7 +225,7 @@ namespace ReactNative.Views.Image
         /// <returns>The image view instance.</returns>
         protected override Border CreateViewInstance(ThemedReactContext reactContext)
         {
-            return new Border
+            return new UIAutomationBorder
             {
                 Background = new ImageBrush
                 {
@@ -327,6 +328,27 @@ namespace ReactNative.Views.Image
                 var bestResult = sources.LocalMin((s) => Math.Abs(s.Value - targetImageSize));
                 SetUriFromSingleSource(view, bestResult.Key);
             }
+        }
+    }
+
+    public class ModifiedBorderAutomationPeer : FrameworkElementAutomationPeer
+    {
+        public ModifiedBorderAutomationPeer(Border owner) : base(owner)
+        {
+
+        }
+
+        protected override bool IsControlElementCore()
+        {
+            return true;
+        }
+    }
+
+    public class UIAutomationBorder : Border
+    {
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            return new ModifiedBorderAutomationPeer(this);
         }
     }
 }

--- a/ReactWindows/ReactNative.Shared/UIManager/BorderedViewParentManager.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/BorderedViewParentManager.cs
@@ -9,6 +9,7 @@ using Windows.UI.Xaml.Media;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
+using System.Windows.Automation.Peers;
 #endif
 
 namespace ReactNative.UIManager
@@ -188,7 +189,7 @@ namespace ReactNative.UIManager
         protected sealed override Border CreateViewInstance(ThemedReactContext reactContext)
         {
             var inner = CreateInnerElement(reactContext);
-            return new Border
+            return new UIAutomationBorder
             {
                 BorderBrush = s_defaultBorderBrush,
                 Child = inner
@@ -249,6 +250,27 @@ namespace ReactNative.UIManager
                 throw new ArgumentNullException(nameof(parent));
 
             return (TFrameworkElement)parent.Child;
+        }
+    }
+
+    public class ModifiedBorderAutomationPeer : FrameworkElementAutomationPeer
+    {
+        public ModifiedBorderAutomationPeer(Border owner) : base(owner)
+        {
+
+        }
+
+        protected override bool IsControlElementCore()
+        {
+            return true;
+        }
+    }
+
+    public class UIAutomationBorder : Border
+    {
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            return new ModifiedBorderAutomationPeer(this);
         }
     }
 }

--- a/ReactWindows/ReactNative.Shared/UIManager/BorderedViewParentManager.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/BorderedViewParentManager.cs
@@ -253,21 +253,38 @@ namespace ReactNative.UIManager
         }
     }
 
+    /// <summary>
+    /// Custom peer class deriving from FrameworkElementAutomationPeer
+    /// </summary>
     public class ModifiedBorderAutomationPeer : FrameworkElementAutomationPeer
     {
+        /// <summary>
+        /// Modified Border with interactive role.
+        /// </summary>
+        /// <param name="owner">The Border instance.</param>
         public ModifiedBorderAutomationPeer(Border owner) : base(owner)
         {
 
         }
 
+        /// <summary>
+        /// Interactive role in the user interface
+        /// </summary>
+        /// <returns> Boolean </returns>
         protected override bool IsControlElementCore()
         {
             return true;
         }
     }
 
+    /// <summary>
+    /// Class providing automation support for the Border element.
+    /// </summary>
     public class UIAutomationBorder : Border
     {
+        /// <summary>
+        /// Class specific AutomationPeer implementation
+        /// </summary>
         protected override AutomationPeer OnCreateAutomationPeer()
         {
             return new ModifiedBorderAutomationPeer(this);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluejeans/react-native-windows",
-  "version": "0.42.1-rc.24",
+  "version": "0.42.1-rc.25",
   "description": "React Native platform extensions for the Universal Windows Platform.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
ReactNative elements like View, Image, Touchable* elements were not visible in UI inspect tools like Inspect.Exe, UISpy etc making UI tests not possible because of unreachable elements

More detail description/Fix is documented at http://confluence.corp.bluejeans.com:8090/display/CBLUE/Doof+Automation

There is already an existing issue filed in the upstream project at 
https://github.com/Microsoft/react-native-windows/issues/1396