### PR TITLE
Fix BlurTextInput Command Handler

### DIFF
--- a/ReactWindows/ReactNative.Net46/ReactNative.Net46.csproj
+++ b/ReactWindows/ReactNative.Net46/ReactNative.Net46.csproj
@@ -160,6 +160,7 @@
       <DependentUpon>RedBoxDialog.xaml</DependentUpon>
     </Compile>
     <Compile Include="DevSupport\WebSocketJavaScriptExecutor.cs" />
+    <Compile Include="Views\UIElementExtensions.cs" />
     <Compile Include="Modules\Dialog\DialogModule.cs" />
     <Compile Include="Modules\Image\BitmapImageHelpers.cs" />
     <Compile Include="Modules\Image\ImageLoaderModule.cs" />

--- a/ReactWindows/ReactNative.Net46/Views/TextInput/ReactPasswordBoxManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/TextInput/ReactPasswordBoxManager.cs
@@ -2,6 +2,7 @@
 using ReactNative.Reflection;
 using ReactNative.UIManager;
 using ReactNative.UIManager.Annotations;
+using ReactNative.Views.Extensions;
 using ReactNative.Views.Text;
 using System;
 using System.Collections.Generic;
@@ -358,7 +359,7 @@ namespace ReactNative.Views.TextInput
             }
             else if (commandId == ReactTextInputManager.BlurTextInput)
             {
-                Keyboard.ClearFocus();
+                view.Blur();
             }
         }
 

--- a/ReactWindows/ReactNative.Net46/Views/TextInput/ReactTextInputManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/TextInput/ReactTextInputManager.cs
@@ -2,6 +2,7 @@
 using ReactNative.Reflection;
 using ReactNative.UIManager;
 using ReactNative.UIManager.Annotations;
+using ReactNative.Views.Extensions;
 using ReactNative.Views.Text;
 using System;
 using System.Collections.Generic;
@@ -423,7 +424,7 @@ namespace ReactNative.Views.TextInput
             }
             else if (commandId == BlurTextInput)
             {
-                Keyboard.ClearFocus();
+                view.Blur();
             }
         }
 
@@ -584,7 +585,7 @@ namespace ReactNative.Views.TextInput
                     e.Handled = true;
                     if (blurOnSubmit)
                     {
-                        Keyboard.ClearFocus();
+                        textBox.Blur();
                     }
                     textBox.GetReactContext()
                         .GetNativeModule<UIManagerModule>()

--- a/ReactWindows/ReactNative.Net46/Views/UIElementExtensions.cs
+++ b/ReactWindows/ReactNative.Net46/Views/UIElementExtensions.cs
@@ -1,0 +1,37 @@
+﻿using System.Windows;
+using System.Windows.Input;
+
+namespace ReactNative.Views.Extensions
+{
+    /// <summary>
+    /// Extension methods for <see cref="UIElement"/>
+    /// </summary>
+    public static class UIElementExtensions
+    {
+        /// <summary>
+        /// Move focus away from the specified <see cref="UIElement"/>
+        /// </summary>
+        /// <param name="uiElement">The <see cref="UIElement"/> to blur</param>
+        public static void Blur(this UIElement uiElement)
+        {
+            if (uiElement == null)
+            {
+                return;
+            }
+
+            var window = FocusManager.GetFocusScope(uiElement) as Window;
+
+            if (window != null)
+            {
+                FocusManager.SetFocusedElement(window, window);
+            }
+            else
+            {
+                var tRequest = new TraversalRequest(FocusNavigationDirection.Next);
+
+                uiElement.MoveFocus(tRequest);
+            }
+        }
+    }
+
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluejeans/react-native-windows",
-  "version": "0.42.1-rc.26",
+  "version": "0.42.1-rc.27",
   "description": "React Native platform extensions for the Universal Windows Platform.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
It appears that the React Native code executes a command on the TextInput when a click is received outside of the TextInput control... This executes the ReceiveCommand override in the ReactTextInputManager, which was previously calling Keyboard.ClearFocus. 

Keyboard.ClearFocus clears the keyboard focus from all controls in the visual tree (or at least the focus scope)... This means that there is nothing that has the keyboard focus.   Calling ClearFocus will not cause a lost focus to be raised on the text box, which means that the onBlur will never be called.

The UWP code gets the current window and then gets the content of the window AS a frame and if that is not null it sets the focus to that object.

This PR does something similar using focus scope to get the target of the new focus