### PR TITLE
Fixed double openeing storage file

### DIFF
--- a/ReactWindows/ReactNative.Net46/Modules/Storage/AsyncStorageModule.cs
+++ b/ReactWindows/ReactNative.Net46/Modules/Storage/AsyncStorageModule.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json.Linq;
 using PCLStorage;
 using ReactNative.Bridge;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -340,10 +341,20 @@ namespace ReactNative.Modules.Storage
 
         private async Task<JObject> SetAsync(string key, string value)
         {
-            var storageFolder = await GetAsyncStorageFolder(true).ConfigureAwait(false);
-            var file = await storageFolder.CreateFileAsync(AsyncStorageHelpers.GetFileName(key), CreationCollisionOption.ReplaceExisting).ConfigureAwait(false);
-            await FileExtensions.WriteAllTextAsync(file, value).ConfigureAwait(false);
-            return default(JObject);
+            try
+            {
+                var storageFolder = await GetAsyncStorageFolder(true).ConfigureAwait(false);
+                var file = await storageFolder.CreateFileAsync(AsyncStorageHelpers.GetFileName(key), CreationCollisionOption.OpenIfExists).ConfigureAwait(false);
+                await FileExtensions.WriteAllTextAsync(file, value).ConfigureAwait(false);
+                return default(JObject);
+            }
+            catch (Exception ex)
+            {
+                return new JObject {
+                                { "message", ex.Message },
+                                { "fileName", ex.ToString()}
+                            };
+            }
         }
 
         private async Task<IFolder> GetAsyncStorageFolder(bool createIfNotExists)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluejeans/react-native-windows",
-  "version": "0.42.1-rc.36",
+  "version": "0.42.1-rc.37",
   "description": "React Native platform extensions for the Universal Windows Platform.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
The problem was that during save data we're doing following sequence:

1. delete old file
2. create new file
3. close new file
4. open new file for writing.
5. write and close file.

The crash happens after step 3. When on step 4 we try to open file it was locked by antivirus. The fix consists of 2 parts:
1. Error handling - instead of crash we report about error via callback mechanism
2. Replace sequence of operation if file exists we simply open it and write new data. No needs to close and immediately reopen it.
