### PR TITLE
DOOF-3689 Fix if-none-match header exception.

### DIFF
--- a/ReactWindows/ReactNative.Shared/Modules/Network/NetworkingModule.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Network/NetworkingModule.cs
@@ -458,6 +458,9 @@ namespace ReactNative.Modules.Network
                     case "content-length":
                     case "content-type":
                         break;
+                    case "if-none-match":
+                        request.Headers.TryAddWithoutValidation(key, header[1]);
+                        break;
                     default:
                         request.Headers.Add(key, header[1]);
                         break;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluejeans/react-native-windows",
-  "version": "0.42.1-rc.41",
+  "version": "0.42.1-rc.42",
   "description": "React Native platform extensions for the Universal Windows Platform.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Etag is supposed to be a quoted string as per the standards but it may be possible/acceptable that a server does not accept an ETag in quotes like for an example "8001" and in particular our server side implementation of an Etag does not accept a quoted string like "8001".

So for this purpose we have to relax the validation on the if-none-match header. Without this fix, the .Add first parses the value to perform validation before trying to add the header value and fails with formatException if not given a quoted string and the quoted string is unfortunately not accepted by the server side implementation.  

.TryAddWithoutValidation does not try to parse the value it is given to see if it is valid