### PR TITLE
Auxiliary views widget support

### DIFF
--- a/ReactWindows/ReactNative.Net46/ReactPage.cs
+++ b/ReactWindows/ReactNative.Net46/ReactPage.cs
@@ -141,7 +141,11 @@ namespace ReactNative
             RootView.FocusVisualStyle = null;
         }
 
-
+        /// <summary>
+        /// When overridden, gets any auxiliary roots views and their associated react components names.
+        /// This is infrastructure for using multiple windows to pop-up such as chat-widget.
+        /// </summary>
+        /// <returns></returns>
         public virtual List<(ReactRootView View, string ReactComponentName)> GetAuxiliaryViews()
         {
             return new List<(ReactRootView View, string ReactComponentName)>();

--- a/ReactWindows/ReactNative.Net46/ReactPage.cs
+++ b/ReactWindows/ReactNative.Net46/ReactPage.cs
@@ -128,13 +128,23 @@ namespace ReactNative
         {
             ApplyArguments(arguments);
             RootView.StartReactApplication(ReactInstanceManager, MainComponentName, initialProps);
-
+            // Instantiate any other auxiliary views
+            var auxViews = GetAuxiliaryViews();
+            foreach (var auxView in auxViews)
+            {
+                auxView.View.StartReactApplication(ReactInstanceManager, auxView.ReactComponentName, initialProps);
+            }
             RootView.AddHandler(Keyboard.KeyDownEvent, (KeyEventHandler)OnAcceleratorKeyActivated);
-
             RootView.Focusable = true;
             KeyboardNavigation.SetIsTabStop(RootView, false);
             RootView.Focus();
             RootView.FocusVisualStyle = null;
+        }
+
+
+        public virtual List<(ReactRootView View, string ReactComponentName)> GetAuxiliaryViews()
+        {
+            return new List<(ReactRootView View, string ReactComponentName)>();
         }
 
         /// <summary>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluejeans/react-native-windows",
-  "version": "0.57.0-rc.45",
+  "version": "0.57.0-ac.46",
   "description": "React Native platform extensions for the Universal Windows Platform.",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluejeans/react-native-windows",
-  "version": "0.57.0-rc.46",
+  "version": "0.57.0-rc.47",
   "description": "React Native platform extensions for the Universal Windows Platform.",
   "license": "MIT",
   "repository": {
@@ -66,7 +66,7 @@
     "xml-parser": "^1.2.1"
   },
   "resolutions": {
-      "metro-config": "bluejeans/metro-config-hotfix-0.48.5"
+    "metro-config": "bluejeans/metro-config-hotfix-0.48.5"
   },
   "rnpm": {
     "haste": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluejeans/react-native-windows",
-  "version": "0.57.0-ac.46",
+  "version": "0.57.0-rc.46",
   "description": "React Native platform extensions for the Universal Windows Platform.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Adds support to create a React Root Views for components other than main using the same context. This will help host react contents in new windows.